### PR TITLE
Fix syntax error in snippets_menu pandas.js that breaks SnippetsMenu

### DIFF
--- a/src/jupyter_contrib_nbextensions/nbextensions/snippets_menu/snippets_submenus_python/pandas.js
+++ b/src/jupyter_contrib_nbextensions/nbextensions/snippets_menu/snippets_submenus_python/pandas.js
@@ -116,11 +116,11 @@ define({
             'sub-menu' : [
                 {
                     'name' : 'Split-apply-combine (sum)',
-                    'snippet' : ['df['label_count'] = df.groupby('label', as_index=False)['label'].transform(lambda x: x.count())',],
+                    'snippet' : ['df["label_count"] = df.groupby("label", as_index=False)["label"].transform(lambda x: x.count())',],
                 },
                 {
                     'name' : 'Split-apply-combine (mean)',
-                    'snippet' : ['df['label_mean'] = df.groupby('label', as_index=False)['label'].transform(lambda x: x.mean())',],
+                    'snippet' : ['df["label_mean"] = df.groupby("label", as_index=False)["label"].transform(lambda x: x.mean())',],
                 },
             ],
         },


### PR DESCRIPTION
There was a syntax error introduced to the pandas snippets in commit d0fb8668c1158fd17a803ebd3fda0b01014b7021, since it attempted to use single quotes within a single-quoted string.

Without this fix, the Snippets menu would entirely fail to load if the built-in Pandas snippets are included (as is the default), with the dev tools console reporting `Uncaught SyntaxError: Unexpected identifier 'label_count' (at pandas.js?v=20230413134100:119:39) 13:49:07.959 `. This should resolve the problem and ensure that the default SnippetsMenu works again, and that pandas snippets can be included.

---

As a workaround until this is merged and published, for anyone who comes across this, you can uncheck the "Include pandas sub-menu" option for Snippets Menu in the Nbextensions UI, or equivalently set `"snippets": {"include_submenu": { "pandas": false, } }` within your nbconfig file (which can be found at `echo $(jupyter --config-dir)/nbconfig/notebook.json`).